### PR TITLE
Add Dockerfile for authentication service setup

### DIFF
--- a/authentications/Dockerfile
+++ b/authentications/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.23.4-alpine
+
+ENV GO111MODULE=on
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+EXPOSE 8080
+
+# Jalankan aplikasi
+CMD ["go", "run", "./cmd/api/main.go"]


### PR DESCRIPTION
This pull request includes a new Dockerfile for the `authentications` service to set up a Go application environment. The Dockerfile specifies the base image, environment variables, working directory, dependencies, and the command to run the application.

* [`authentications/Dockerfile`](diffhunk://#diff-636f936d9b4f8d30a86423b60d530facde23fecdb0aa399ffbf3868facc543c7R1-R16): Added a new Dockerfile to set up a Go application environment using the `golang:1.23.4-alpine` base image, setting the `GO111MODULE` environment variable, copying necessary files, downloading dependencies, exposing port 8080, and running the application with `go run`.