### PR TITLE
Update Dockerfile to expose port 9001 for authentication service

### DIFF
--- a/authentications/Dockerfile
+++ b/authentications/Dockerfile
@@ -10,6 +10,6 @@ RUN go mod download
 
 COPY . .
 
-EXPOSE 8080
+EXPOSE 9001
 
 CMD ["go", "run", "./cmd/api/main.go"]


### PR DESCRIPTION
This pull request includes a small change to the `authentications/Dockerfile`. The change modifies the port exposed by the Docker container from 8080 to 9001.

* [`authentications/Dockerfile`](diffhunk://#diff-636f936d9b4f8d30a86423b60d530facde23fecdb0aa399ffbf3868facc543c7L13-R13): Changed the exposed port from 8080 to 9001.