### PR TITLE
Update Dockerfile to use Go 1.23.5 and set environment variables for …

### DIFF
--- a/authentications/Dockerfile
+++ b/authentications/Dockerfile
@@ -1,6 +1,9 @@
-FROM golang:1.23.4-alpine
+FROM golang:1.23.5-alpine
 
-ENV GO111MODULE=on
+ENV GO111MODULE=on \
+    CGO_ENABLED=0 \
+    GOOS=linux \
+    GOARCH=amd64
 
 WORKDIR /app
 


### PR DESCRIPTION
This pull request includes updates to the `authentications/Dockerfile` to improve the build environment and configuration.

Build environment improvements:

* [`authentications/Dockerfile`](diffhunk://#diff-636f936d9b4f8d30a86423b60d530facde23fecdb0aa399ffbf3868facc543c7L1-R6): Updated the Go version from `1.23.4-alpine` to `1.23.5-alpine`.

Configuration improvements:

* [`authentications/Dockerfile`](diffhunk://#diff-636f936d9b4f8d30a86423b60d530facde23fecdb0aa399ffbf3868facc543c7L1-R6): Added environment variables `CGO_ENABLED=0`, `GOOS=linux`, and `GOARCH=amd64` to the Dockerfile.…cross-compilation