### PR TITLE
Feat/mails

### DIFF
--- a/mails/.gitignore
+++ b/mails/.gitignore
@@ -1,1 +1,2 @@
 .env
+.idea

--- a/mails/cmd/main.go
+++ b/mails/cmd/main.go
@@ -28,6 +28,7 @@ func main() {
 
 	router := events.NewEventRouter()
 	router.Register("user_registered", handlers.UserRegisteredHandler(mailer))
+	router.Register("export_playlist", handlers.ExportPlaylistHandler(mailer))
 
 	sub, err := rabbitmq.NewSubscriber(conn, "email_events")
 	if err != nil {

--- a/mails/internal/email/templates/export_playlist.html
+++ b/mails/internal/email/templates/export_playlist.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Your Exported Playlist</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f9f9f9;
+        }
+        .container {
+            max-width: 600px;
+            margin: auto;
+            background: #ffffff;
+            padding: 20px;
+            border-radius: 5px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+        .header {
+            text-align: center;
+            margin-bottom: 20px;
+        }
+        .playlist-info {
+            background: #f1f1f1;
+            padding: 10px;
+            border-radius: 5px;
+            margin-bottom: 20px;
+        }
+        .song-list {
+            list-style-type: none;
+            padding: 0;
+        }
+        .song-list li {
+            padding: 8px;
+            border-bottom: 1px solid #ddd;
+        }
+        .footer {
+            text-align: center;
+            font-size: 12px;
+            color: #555;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="header">
+        <h1>Your Exported Playlist</h1>
+    </div>
+
+    <div class="playlist-info">
+        <h2>{{ .PlaylistName }}</h2>
+    </div>
+
+    <h3>Song List:</h3>
+    <ul class="song-list">
+        {{ range .Songs }}
+        <li>
+            <strong>{{ .Title }}</strong> - {{ .Artist }} ({{ .Year }})
+        </li>
+        {{ end }}
+    </ul>
+
+    <p>Thank you for using MicroMusic. Enjoy your playlist!</p>
+
+    <div class="footer">
+        <p>&copy; 2024 MicroMusic. All rights reserved.</p>
+    </div>
+</div>
+</body>
+</html>

--- a/mails/internal/handlers/export_playlist_handler.go
+++ b/mails/internal/handlers/export_playlist_handler.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"encoding/json"
+
+	"github.com/ardwiinoo/micro-music/mails/internal/email"
+)
+
+type ExportPlaylistPayload struct {
+	Email      string `json:"email"`
+	PlaylistID string `json:"playlist_id"`
+	Playlist   string `json:"playlist"`
+}
+
+func ExportPlaylistHandler(mailer *email.Mailer) func([]byte) error {
+	return func(payload []byte) error {
+		var data ExportPlaylistPayload
+
+		if err := json.Unmarshal(payload, &data); err != nil {
+			return err
+		}
+
+		var playlist struct {
+			PlaylistID   string `json:"playlist_id"`
+			PlaylistName string `json:"playlist_name"`
+			Songs        []struct {
+				Title  string `json:"title"`
+				Artist string `json:"artist"`
+				Year   int    `json:"year"`
+			} `json:"songs"`
+		}
+
+		if err := json.Unmarshal([]byte(data.Playlist), &playlist); err != nil {
+			return err
+		}
+
+		return mailer.SendMail(
+			data.Email,
+			"Your Exported Playlist - MicroMusic",
+			"export_playlist.html",
+			map[string]interface{}{
+				"PlaylistName": playlist.PlaylistName,
+				"Songs":        playlist.Songs,
+			},
+		)
+	}
+}


### PR DESCRIPTION
This pull request introduces a new feature for exporting playlists via email in the `mails` service. The changes include updates to the event router, a new email handler, and an HTML email template.

### New Feature: Export Playlist Email

* [`mails/cmd/main.go`](diffhunk://#diff-f8553f2836d7e2338e15221c56026f87fa8bdc839c2466e3ea8ca68547e7e0d9R31): Registered the new `export_playlist` event with the `ExportPlaylistHandler`.
* [`mails/internal/handlers/export_playlist_handler.go`](diffhunk://#diff-d6731c594ed774bb9615f012447c2254d2bd689792f34e1cfb5bc9964b949519R1-R47): Added a new handler `ExportPlaylistHandler` to process the `export_playlist` event and send an email with the exported playlist details.
* [`mails/internal/email/templates/export_playlist.html`](diffhunk://#diff-2f85b285dcac76bd6c49c6a68516a3ad44a7f7d5348972389c018c2d34fb7874R1-R74): Created a new HTML template for the exported playlist email, including styles and placeholders for playlist information.

### Other Changes

* [`mails/.gitignore`](diffhunk://#diff-51d0622ec58d01adfd50388e3fb22af67baae28f07363599de6413be268f0549R2): Added `.idea` to the `.gitignore` file to exclude IDE configuration files.