### PR TITLE
Feat/music

### DIFF
--- a/musics/internal/applications/use_case/stream_song_use_case.go
+++ b/musics/internal/applications/use_case/stream_song_use_case.go
@@ -2,14 +2,13 @@ package usecase
 
 import (
 	"context"
-	"fmt"
 	"github.com/ardwiinoo/micro-music/musics/internal/domains/songs"
 	"io"
 	"net/http"
 )
 
 type StreamSongUseCase interface {
-	Execute(ctx context.Context, songId string, rangeHeader string) (io.ReadCloser, int, string, error)
+	Execute(ctx context.Context, songId string, rangeHeader string) (io.ReadCloser, int, string, http.Header, error)
 }
 
 type streamSongUseCase struct {
@@ -22,15 +21,15 @@ func NewStreamSongUseCase(songRepository songs.SongRepository) StreamSongUseCase
 	}
 }
 
-func (s *streamSongUseCase) Execute(ctx context.Context, songID string, rangeHeader string) (io.ReadCloser, int, string, error) {
+func (s *streamSongUseCase) Execute(ctx context.Context, songID string, rangeHeader string) (io.ReadCloser, int, string, http.Header, error) {
 	song, err := s.songRepository.GetSongById(ctx, songID)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, 0, "", nil, err
 	}
 
 	req, err := http.NewRequest("GET", song.Url, nil)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, 0, "", nil, err
 	}
 
 	if rangeHeader != "" {
@@ -40,21 +39,12 @@ func (s *streamSongUseCase) Execute(ctx context.Context, songID string, rangeHea
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, 0, "", err
+		return nil, 0, "", nil, err
 	}
 
-	contentLength := resp.ContentLength
-	contentRange := resp.Header.Get("Content-Range")
-
-	statusCode := http.StatusOK
-	if rangeHeader != "" {
-		statusCode = http.StatusPartialContent
-	}
-
-	fmt.Println("Status Code:", statusCode)
-	fmt.Println("Content-Type:", resp.Header.Get("Content-Type"))
-	fmt.Println("Content-Length:", contentLength)
-	fmt.Println("Content-Range:", contentRange)
-
-	return resp.Body, statusCode, resp.Header.Get("Content-Type"), nil
+	return resp.Body,
+		resp.StatusCode, // from firebase
+		resp.Header.Get("Content-Type"),
+		resp.Header,
+		nil
 }


### PR DESCRIPTION
This pull request includes changes to the `StreamSongUseCase` and its usage in the `StreamSongHandler` to include HTTP headers in the response. The most important changes include modifying the `Execute` method to return HTTP headers, updating the handler to set these headers in the response, and removing unnecessary logging.

Changes to `StreamSongUseCase`:

* [`musics/internal/applications/use_case/stream_song_use_case.go`](diffhunk://#diff-c9d9d75a71a62305659b1f7897b6f2abc94f4e3d9494b7b97d8af6c14dc3c4bbL5-R11): Modified the `Execute` method to return `http.Header` and updated the method implementation to include headers in the response. [[1]](diffhunk://#diff-c9d9d75a71a62305659b1f7897b6f2abc94f4e3d9494b7b97d8af6c14dc3c4bbL5-R11) [[2]](diffhunk://#diff-c9d9d75a71a62305659b1f7897b6f2abc94f4e3d9494b7b97d8af6c14dc3c4bbL25-R32) [[3]](diffhunk://#diff-c9d9d75a71a62305659b1f7897b6f2abc94f4e3d9494b7b97d8af6c14dc3c4bbL43-R49)

Changes to `StreamSongHandler`:

* [`musics/internal/interfaces/songs/handler.go`](diffhunk://#diff-23e7ad4bcf20ec472dfd04e792e0409d118374be40ebdada4fee2e60930a3809L107-L123): Updated the `StreamSongHandler` to handle the additional headers returned by the `Execute` method and set them in the response.