### PR TITLE
Feat/music

### DIFF
--- a/musics/docs/docs.go
+++ b/musics/docs/docs.go
@@ -154,7 +154,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "Range",
+                        "description": "Range, ex: Range: bytes=0-1023",
                         "name": "Range",
                         "in": "header"
                     }

--- a/musics/docs/swagger.json
+++ b/musics/docs/swagger.json
@@ -143,7 +143,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "Range",
+                        "description": "Range, ex: Range: bytes=0-1023",
                         "name": "Range",
                         "in": "header"
                     }

--- a/musics/docs/swagger.yaml
+++ b/musics/docs/swagger.yaml
@@ -91,7 +91,7 @@ paths:
         name: id
         required: true
         type: string
-      - description: Range
+      - description: 'Range, ex: Range: bytes=0-1023'
         in: header
         name: Range
         type: string

--- a/musics/internal/interfaces/songs/handler.go
+++ b/musics/internal/interfaces/songs/handler.go
@@ -95,7 +95,7 @@ func (s *songHandler) addSongHandler(ctx *fiber.Ctx) error {
 // @Accept       */*
 // @Produce      audio/mpeg
 // @Param        id   path      string  true  "Song ID"
-// @Param        Range header   string  false "Range"
+// @Param        Range header   string  false "Range, ex: Range: bytes=0-1023"
 // @Success      206 {file} audio/mpeg
 // @Failure      404 {object} map[string]interface{}
 // @Failure      500 {object} map[string]interface{}


### PR DESCRIPTION
This pull request includes updates to the documentation for the `Range` header across multiple files in the `musics` module. The changes provide a clearer example of the expected format for the `Range` header.

Documentation improvements:

* [`musics/docs/docs.go`](diffhunk://#diff-c20b6da71c66407a4537c63a354a56df02e0d521b7bfcad9deacac9c9374850fL157-R157): Updated the description of the `Range` header to include an example format.
* [`musics/docs/swagger.json`](diffhunk://#diff-d2f86d3cb45c95460e2ba6fe5e7332cc28044cf61ab082660bbd8325db9ed2d1L146-R146): Updated the description of the `Range` header to include an example format.
* [`musics/docs/swagger.yaml`](diffhunk://#diff-5f849e06f013cee0cbd45f7d0f7068bf45403c78aaab9c3674cf357f6dd02e5cL94-R94): Updated the description of the `Range` header to include an example format.
* [`musics/internal/interfaces/songs/handler.go`](diffhunk://#diff-23e7ad4bcf20ec472dfd04e792e0409d118374be40ebdada4fee2e60930a3809L98-R98): Updated the description of the `Range` header in the `addSongHandler` function to include an example format.